### PR TITLE
Fix API server cert creation - lbaas-port specification

### DIFF
--- a/docs/04-certificate-authority.md
+++ b/docs/04-certificate-authority.md
@@ -295,7 +295,7 @@ Generate the Kubernetes API Server certificate and private key:
 {
 
 KUBERNETES_PUBLIC_ADDRESS=$(for id in {1..3}; do openstack server show kube-controller-$id -f value -c addresses|cut -d',' -f2|tr -d ' '|tr '\n' ','; done)
-LOADBALANCER_IP=$(openstack floating ip list --port 6f06cb1c-b433-47de-8da4-4a60e064a923 -f value -c "Floating IP Address")
+LOADBALANCER_IP=$(openstack floating ip list --port $(neutron lbaas-loadbalancer-show kubernetes-the-hard-way -f=value -c vip_port_id) -f value -c "Floating IP Address")
 
 cat > kubernetes-csr.json <<EOF
 {


### PR DESCRIPTION
lbaas-port specification in step "API server cert creation" was fixed to a specific port-id
changed it to dynamic port specification by executing `neutron lbaas-loadbalancer-show kubernetes-the-hard-way -f=value -c vip_port_id`